### PR TITLE
Handle buffers

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,11 +24,15 @@ received.
 Asserts exchange specified in [`config`](#config). Then publishes `message` to
 that exchange with routing key, `key` and `options` (if they exist) as in
 [amqplib](http://www.squaremobius.net/amqp.node/doc/channel_api.html#toc_60).
+If message is a `Buffer`, it is sent as is, otherwise, it is serialized to JSON
+and sent.
 
 ### `AMQP.sendToQueue(config, message, [options])` -> `Promise`
 Asserts queue specified in [`config`](#config). Then sends `message` to that
 queue with `options` (if they exist) as in
 [amqplib](http://www.squaremobius.net/amqp.node/doc/channel_api.html#toc_60).
+If message is a `Buffer`, it is sent as is, otherwise, it is serialized to JSON
+and sent.
 
 ### `AMQP.connect()` -> `Promise`
 Returns [`amqplib` connection]

--- a/index.js
+++ b/index.js
@@ -19,6 +19,13 @@ function cleanup(done) {
   ).nodeify(done);
 }
 
+function toBuffer(obj) {
+  if (obj instanceof Buffer) {
+    return obj;
+  }
+  return new Buffer(JSON.stringify(obj));
+}
+
 diehard.register(cleanup);
 
 module.exports = function (amqpUrl) {
@@ -132,7 +139,7 @@ module.exports = function (amqpUrl) {
       .then(function (ch) {
         return ch.publish(queueConfig.exchange,
           key,
-          new Buffer(JSON.stringify(json)),
+          toBuffer(json),
           messageOptions || queueConfig.messageOptions || {persistent: true});
       });
   }
@@ -148,7 +155,7 @@ module.exports = function (amqpUrl) {
           .then(function () {
             return ch.sendToQueue(
               queueConfig.queue,
-              new Buffer(JSON.stringify(json)),
+              toBuffer(json),
               messageOptions || queueConfig.messageOptions || {persistent: true}
             );
           });

--- a/test/index.js
+++ b/test/index.js
@@ -31,7 +31,7 @@ describe('amqplib-easy', function () {
       });
   });
 
-  describe('should publish, sendToQueue and receive', function () {
+  describe('', function () {
     var cancel;
 
     afterEach(function () {
@@ -40,7 +40,37 @@ describe('amqplib-easy', function () {
       }
     });
 
-    it('', function (done) {
+    it('should handle buffers reasonably', function (done) {
+      var catCount = 0;
+      amqp.consume(
+        {
+          exchange: 'cat',
+          queue: 'found_cats',
+          topics: [ 'found.*' ]
+        },
+        function (cat) {
+          var name = cat.json.name;
+          try {
+            /*eslint-disable no-unused-expressions*/
+            (name === 'Sally' || name === 'Fred').should.be.ok;
+            /*eslint-enable no-unused-expressions*/
+            if (++catCount === 2) {
+              done();
+            }
+          } catch (err) { done(err); }
+        }
+      )
+        .then(function (c) {
+          cancel = c;
+          return BPromise.all([
+            amqp.publish({ exchange: 'cat' }, 'found.tawny', new Buffer('{ "name": "Sally" }')),
+            amqp.sendToQueue({ queue: 'found_cats' }, new Buffer('{ "name": "Fred" }'))
+          ]);
+        })
+        .catch(done);
+    });
+
+    it('should publish, sendToQueue and receive', function (done) {
       var catCount = 0;
       amqp.consume(
         {


### PR DESCRIPTION
This adds support for directly sending buffers to AMQP in the case where you have a large object already in a `Buffer` you don't want to deserialize and serialize before sending.