### PR TITLE
Better channel management for sending

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs-v1"
-  - "iojs-v2"
   - "4"
 services:
   - rabbitmq-server

--- a/API.md
+++ b/API.md
@@ -1,15 +1,18 @@
-- [`Create(amqpUrl)`](#createamqpurl---amqp)
+- [`Create(amqpUrl)`](#createamqpurl-socketoptions---amqp)
 - [`AMQP.consume(config, handler)`](#amqpconsumeconfig-handler---cancellationpromise)
 - [`AMQP.publish(config, key, message, [options])`](#amqppublishconfig-key-message-options---promise)
 - [`AMQP.sendToQueue(config, message, [options])`](#amqpsendtoqueueconfig-message-options---promise)
 - [`AMQP.connect()`](#amqpconnect---promise)
 - [`Config`](#config)
 
-### `Create(amqpUrl)` -> `AMQP`
+### `Create(amqpUrl, [socketOptions])` -> `AMQP`
 Create an `AMQP` which connects to `amqpUrl`. E.g.,
 ```javascript
 var amqp = require('amqplib-easy')('amqp://guest:guest@localhost');
 ```
+
+[`socketOptions`](http://www.squaremobius.net/amqp.node/channel_api.html#connect)
+default to `maxChannels: 100`.
 
 ### `AMQP.consume(config, handler)` -> `CancellationPromise`
 Asserts queue and exchange specified in [`config`](#config) and binds them

--- a/index.js
+++ b/index.js
@@ -29,10 +29,13 @@ function toBuffer(obj) {
 
 diehard.register(cleanup);
 
-module.exports = function (amqpUrl) {
+module.exports = function (amqpUrl, socketOptions) {
   function connect() {
     if (!connections[amqpUrl]) {
-      connections[amqpUrl] = BPromise.resolve(amqp.connect(amqpUrl));
+      socketOptions = defaults({}, socketOptions || {}, {
+        channelMax: 100
+      });
+      connections[amqpUrl] = BPromise.resolve(amqp.connect(amqpUrl, socketOptions));
     }
     return connections[amqpUrl];
   }

--- a/test/index.js
+++ b/test/index.js
@@ -31,7 +31,7 @@ describe('amqplib-easy', function () {
       });
   });
 
-  describe('', function () {
+  describe('consumer', function () {
     var cancel;
 
     afterEach(function () {
@@ -124,6 +124,27 @@ describe('amqplib-easy', function () {
         })
         .catch(done);
 
+    });
+
+    it('should publish even if something causes the channel to die', function (done) {
+      amqp.consume(
+        {
+          exchange: 'cat',
+          queue: 'found_cats',
+          topics: [ 'found.*' ]
+        },
+        function () {
+          done();
+        }
+      )
+        .then(function (c) {
+          cancel = c;
+          return amqp.publish({ exchange: 'cat', exchangeType: 'direct' }, 'found.tawny', { name: 'Sally' })
+            .catch(function () {
+              return amqp.publish({ exchange: 'cat', exchangeType: 'topic' }, 'found.tawny', { name: 'Sally' });
+            });
+        })
+        .catch(done);
     });
   });
 


### PR DESCRIPTION
This makes it so that a single channel is used for sending messages instead of creating a channel per publish. Additionally, this single channel is a confirm channel so that messages are now confirmed as received by the server before the promise for that `publish` or `sendToQueue` is resolved. Finally, the `maxChannels` has been set to avoid bringing down a rabbitmq server by creating too many channels.