### PR TITLE
pass delay function option to channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,7 @@ module.exports = function (amqpUrl, socketOptions) {
                 channel: ch,
                 consumerQueue: options.queue,
                 failureQueue: options.retry.failQueue,
+                delay: options.retry.delay,
                 handler: function (msg) {
                   if (!msg) {
                     return


### PR DESCRIPTION
Hello. This little change goes along with #36 from drobertus. It simply passes along a delay function defined by the consuming app along to the retry function. It looks to me that shouldnt cause problems as the retry module should still use its default if this is left undefined.