### PR TITLE
Add Error Handler for Cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function cleanup (done) {
         }).catch(function (err) {
           // this catch is necessary that all connections get closed – even if
           // there are not established – without affection others.
-          console.warn(err.toString());
+          console.warn(err.toString())
         })
     })
     .then(function () {

--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ function cleanup (done) {
         .then(function (connection) {
           return connection.close()
         }).catch(function (err) {
-          // this catch is necessary that all connections get closed – even if
-          // there are not established – without affection others.
+          // this catch is necessary so that all single connections get closed and
+          // cleared, even if they are not established, without affection others.
           console.warn(err.toString())
         })
     })

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function cleanup (done) {
       return connections[connectionUrl]
         .then(function (connection) {
           return connection.close()
-        })
+        }).catch(function () {})
     })
     .then(function () {
       connections = {}

--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ function cleanup (done) {
       return connections[connectionUrl]
         .then(function (connection) {
           return connection.close()
-        }).catch(function () {})
+        }).catch(function (err) {
+          // this catch is necessary that all connections get closed – even if
+          // there are not established – without affection others.
+          console.warn(err.toString());
+        })
     })
     .then(function () {
       connections = {}


### PR DESCRIPTION
`connection.close()` throws an error when you try to close a unconnected/failed connection — with the `catch` it closes all connections and clears the `connections` object even if some connections has not succeeded yet.

So it is possible to add custom error handler within the application to reconnect.
w/o it's almost impossible. 

cc @apechimp 