### PR TITLE
Extract closeConnection function

### DIFF
--- a/API.md
+++ b/API.md
@@ -50,7 +50,6 @@ var connection = amqplib('amqp://guest:guest@localhost:1337');
 
 conneciton.close();
 ```
-See above at [`closeConnection`](#closeconnectionamqpurl---promise).
 
 ### `Config`
 Recognized properties follow

--- a/API.md
+++ b/API.md
@@ -42,7 +42,7 @@ Returns [`amqplib` connection]
 (http://www.squaremobius.net/amqp.node/channel_api.html#models)
 for handling use cases not covered by this library, e.g., deleting queues.
 
-### `AMQP.close()` --> `Promise`
+### `AMQP.close()` -> `Promise`
 Close the `AMQP` and delete its `connection` & `sendChannel` without affecting others. E.g.,
 ```javascript
 var amqp = require('amqplib-easy');

--- a/API.md
+++ b/API.md
@@ -14,6 +14,18 @@ var amqp = require('amqplib-easy')('amqp://guest:guest@localhost');
 [`socketOptions`](http://www.squaremobius.net/amqp.node/channel_api.html#connect)
 default to `maxChannels: 100`.
 
+### `closeConnection(amqpUrl)`
+Close an `AMQP` and delete its `connection` & `sendChannel` specified by `amqpUrl` without affecting others. E.g.,
+```javascript
+var amqp = require('amqplib-easy');
+var connection = amqplib('amqp://guest:guest@localhost:1337');
+
+amqp.closeConnection('amqp://guest:guest@localhost:1337');
+```
+
+[`socketOptions`](http://www.squaremobius.net/amqp.node/channel_api.html#connect)
+default to `maxChannels: 100`.
+
 ### `AMQP.consume(config, handler)` -> `CancellationPromise`
 Asserts queue and exchange specified in [`config`](#config) and binds them
 (exchange is optional). Then a consumer is created to consume messages in the

--- a/API.md
+++ b/API.md
@@ -14,7 +14,7 @@ var amqp = require('amqplib-easy')('amqp://guest:guest@localhost');
 [`socketOptions`](http://www.squaremobius.net/amqp.node/channel_api.html#connect)
 default to `maxChannels: 100`.
 
-### `closeConnection(amqpUrl)`
+### `closeConnection(amqpUrl)` -> `Promise`
 Close an `AMQP` and delete its `connection` & `sendChannel` specified by `amqpUrl` without affecting others. E.g.,
 ```javascript
 var amqp = require('amqplib-easy');
@@ -53,6 +53,9 @@ and sent.
 Returns [`amqplib` connection]
 (http://www.squaremobius.net/amqp.node/channel_api.html#models)
 for handling use cases not covered by this library, e.g., deleting queues.
+
+### `AMQP.close()` --> `Promise`
+See above at [`closeConnection`](#closeconnectionamqpurl---promise).
 
 ### `Config`
 Recognized properties follow

--- a/API.md
+++ b/API.md
@@ -14,18 +14,6 @@ var amqp = require('amqplib-easy')('amqp://guest:guest@localhost');
 [`socketOptions`](http://www.squaremobius.net/amqp.node/channel_api.html#connect)
 default to `maxChannels: 100`.
 
-### `closeConnection(amqpUrl)` -> `Promise`
-Close an `AMQP` and delete its `connection` & `sendChannel` specified by `amqpUrl` without affecting others. E.g.,
-```javascript
-var amqp = require('amqplib-easy');
-var connection = amqplib('amqp://guest:guest@localhost:1337');
-
-amqp.closeConnection('amqp://guest:guest@localhost:1337');
-```
-
-[`socketOptions`](http://www.squaremobius.net/amqp.node/channel_api.html#connect)
-default to `maxChannels: 100`.
-
 ### `AMQP.consume(config, handler)` -> `CancellationPromise`
 Asserts queue and exchange specified in [`config`](#config) and binds them
 (exchange is optional). Then a consumer is created to consume messages in the
@@ -55,6 +43,13 @@ Returns [`amqplib` connection]
 for handling use cases not covered by this library, e.g., deleting queues.
 
 ### `AMQP.close()` --> `Promise`
+Close the `AMQP` and delete its `connection` & `sendChannel` without affecting others. E.g.,
+```javascript
+var amqp = require('amqplib-easy');
+var connection = amqplib('amqp://guest:guest@localhost:1337');
+
+conneciton.close();
+```
 See above at [`closeConnection`](#closeconnectionamqpurl---promise).
 
 ### `Config`

--- a/API.md
+++ b/API.md
@@ -3,6 +3,7 @@
 - [`AMQP.publish(config, key, message, [options])`](#amqppublishconfig-key-message-options---promise)
 - [`AMQP.sendToQueue(config, message, [options])`](#amqpsendtoqueueconfig-message-options---promise)
 - [`AMQP.connect()`](#amqpconnect---promise)
+- [`AMQP.close()`](#amqpclose---promise)
 - [`Config`](#config)
 
 ### `Create(amqpUrl, [socketOptions])` -> `AMQP`

--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ module.exports = function (amqpUrl, socketOptions) {
     return connections[amqpUrl]
   }
 
+  function close () {
+    return closeConnection(amqpUrl)
+  }
+
   function sendChannel () {
     if (!sendChannels[amqpUrl]) {
       sendChannels[amqpUrl] = connect()
@@ -222,6 +226,7 @@ module.exports = function (amqpUrl, socketOptions) {
 
   return {
     connect: connect,
+    close: close,
     consume: consume,
     publish: publish,
     sendToQueue: sendToQueue

--- a/index.js
+++ b/index.js
@@ -234,4 +234,3 @@ module.exports = function (amqpUrl, socketOptions) {
 }
 
 module.exports.close = cleanup
-module.exports.closeConnection = closeConnection

--- a/test/index.js
+++ b/test/index.js
@@ -284,6 +284,42 @@ describe('amqplib-easy', function () {
 })
 
 describe('Connection managment', function () {
+  it('should close and delete connection – no reuse', function (done) {
+    amqp.connect()
+      .then(function (connection1) {
+        return amqp.close().then(function () {
+          amqp.connect()
+            .then(function (connection2) {
+              connection1.should.not.equal(connection2)
+              done()
+            })
+        })
+      })
+      .catch(done)
+  })
+
+  it('should close/delete connection and reconnect on consume', function (done) {
+    amqp.connect()
+      .then(function (connection1) {
+        return amqp.close().then(function () {
+          amqp.consume({
+            exchange: 'cat',
+            queue: 'found_cats',
+            topics: ['found.*']
+          },
+          function () {
+            done('Got a cat')
+          }).catch(done)
+          .then(function () {
+            amqp.connect().then(function () {
+              done()
+            })
+          })
+        })
+      })
+      .catch(done)
+  })
+
   it('should reuse the existing connection', function (done) {
     amqp.connect()
       .then(function (connection1) {


### PR DESCRIPTION
Extracting the function out of `cleanup` into an own exposed function called `closeConnection` (exposed as `AMQP.close()`) allows additionally to close/delete `connections`/`sendChannels` specified by its AMQP url.

So it is possible to close/delete unwanted `connections` w/o affecting the others.
The former functionality and code has not changed. It's just an extraction.

--

I know that it is possible to close specific connections with `AMQP.connect()` and `connection.close()`. But this way does not enable to delete them out of the `connections`/`sendChannels` objects.