### PR TITLE
Allow to consume binary message content

### DIFF
--- a/API.md
+++ b/API.md
@@ -64,7 +64,23 @@ Recognized properties follow
 - `messageOptions`: (object) of options supported by
   [amqplib](http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish).
   Defaults to an empty object
-- `parse`: (function) parse string content of message. Defaults to `JSON.parse`
+- `parse`: (function) a function which accepts raw message as an argument and returns decoded message content. 
+   
+   Defaults to `jsonDecoder` which simply converts json encoded message content to `Object` by calling `JSON.parse`.
+   The raw message passed as an argument have the following properties:
+
+   ```javascript
+   {
+     content: Buffer,
+     fields: Object,
+     properties: Object
+   } 
+   ```
+
+   See
+   [amqplib.channelConsume](http://www.squaremobius.net/amqp.node/channel_api.html#channel_consume)
+   for more information.
+
 - `prefetch`: (number) of messages to fetch when consuming. Defaults to `1`
 - `arguments`: (object) containing any binding arguments for the queue. Defaults to `{}`
 - `queue`: (string) name of the queue to use

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function toBuffer (obj) {
 
 function jsonDecoder (message) {
   if (!(message && message.content)) return null
-  return JSON.parse(message.content)
+  return JSON.parse(message.content.toString())
 }
 
 diehard.register(cleanup)

--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ function toBuffer (obj) {
   return new Buffer(JSON.stringify(obj))
 }
 
+function jsonDecoder (message) {
+  if (!(message && message.content)) return null
+  return JSON.parse(message.content)
+}
+
 diehard.register(cleanup)
 
 module.exports = function (amqpUrl, socketOptions) {
@@ -78,7 +83,7 @@ module.exports = function (amqpUrl, socketOptions) {
     var options = defaults({}, queueConfig || {}, {
       exchangeType: 'topic',
       exchangeOptions: {durable: true},
-      parse: JSON.parse,
+      parse: jsonDecoder,
       queueOptions: {durable: true},
       prefetch: 1,
       arguments: {}
@@ -120,7 +125,7 @@ module.exports = function (amqpUrl, socketOptions) {
             function parse (msg) {
               return function () {
                 try {
-                  msg.json = options.parse(msg.content.toString())
+                  msg.payload = msg.json = options.parse(msg)
                   return handler(msg, ch)
                 } catch (err) {
                   console.error('Error deserializing AMQP message content.', err)

--- a/test/index.js
+++ b/test/index.js
@@ -52,8 +52,11 @@ describe('amqplib-easy', function () {
         },
         function (cat) {
           var name = cat.json.name
+          var payload = cat.payload
           try {
+            cat.should.have.properties(['content', 'fields', 'properties'])
             name.should.equal('Fred')
+            payload.should.be.deepEqual(cat.json)
             done()
           } catch (err) {
             done(err)


### PR DESCRIPTION
Changes argument passed to `parse` config of `consume` method to raw AMQP message object to allow handling binary message content, which is not currently possible.

As a bonus `parse` implementation has access to `fields` and `properties` properties of the raw AMQP message, which may contain some useful information about a message ex:

- contentType
- contentEncoding
- correlationId
- messageId
- timestamp
- appId
- type

This is a **breaking** change.

Now `parse` config option is a function that accepts following argument:

```javascript
{
   content: Buffer,
   fields: Object,
   properties: Object
}
```

