### PR TITLE
Allow to consume messages from plain queue

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ module.exports = function (amqpUrl, socketOptions) {
             }
 
             return Promise.map(options.topics, function (topic) {
-              return ch.bindQueue(options.queue, options.exchange, topic, options.arguments || {})
+              return options.exchange ? ch.bindQueue(options.queue, options.exchange, topic, options.arguments || {}) : Promise.resolve()
             })
           })
           .then(function () {


### PR DESCRIPTION
PR fixes issue with consuming messages from plain queue (without exchange).
Before change binding to queue (in line 116) fails due to non existing exchange name.